### PR TITLE
Removing the toolbar icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,17 +16,6 @@
    "name": "9GAG NSFW Bypass",
    "short_name": "9GAG NSFW Bypass",
    "permissions": [ "http://9gag.com/", "https://9gag.com/*" ],
-   "browser_action": {
-        "default_icon": {                    
-            "19": "img/icon19.png", 
-			"19_on": "img/icon19_on.png", 
-			"19_off": "img/icon19_off.png", 
-			"38": "img/icon38.png",  
-			"38_on": "img/icon38_on.png",
-			"38_off": "img/icon38_off.png"           
-        },
-        "default_title": "9GAG NSFW Bypass"
-    },
    "web_accessible_resources": [ "img/*.png" ],
    "version": "0.2.6"
 }


### PR DESCRIPTION
The icon (from `browser_action`) does nothing but clutter the browser.

[The documentation](https://developer.chrome.com/extensions/manifest) says that the icon is optional. Alternatively, a [`page_action`](https://developer.chrome.com/extensions/pageAction) is preferred, as the icon will only be visible when browsing 9gag.
